### PR TITLE
fix: enable server script before creating invoices

### DIFF
--- a/approvals/approvals/api.py
+++ b/approvals/approvals/api.py
@@ -1,5 +1,6 @@
-import frappe
 import json
+
+import frappe
 from frappe.desk.form.utils import add_comment
 
 

--- a/approvals/approvals/doctype/document_approval_rule/document_approval_rule.py
+++ b/approvals/approvals/doctype/document_approval_rule/document_approval_rule.py
@@ -1,8 +1,9 @@
 import frappe
-from frappe.model.document import Document
 import frappe.cache_manager
-from frappe import _, get_value, get_all
+from frappe import _, get_all, get_value
+from frappe.model.document import Document
 from frappe.utils.data import today
+
 from approvals.approvals.api import create_approval_notification
 
 

--- a/approvals/approvals/doctype/document_approval_settings/document_approval_settings.py
+++ b/approvals/approvals/doctype/document_approval_settings/document_approval_settings.py
@@ -1,6 +1,7 @@
+import json
+
 import frappe
 from frappe.model.document import Document
-import json
 
 
 class DocumentApprovalSettings(Document):

--- a/approvals/approvals/doctype/user_document_approval/user_document_approval.py
+++ b/approvals/approvals/doctype/user_document_approval/user_document_approval.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.model.document import Document
 from frappe.utils.data import today
+
 from approvals.approvals.api import create_approval_notification
 
 

--- a/approvals/tests/setup.py
+++ b/approvals/tests/setup.py
@@ -1,17 +1,12 @@
 import datetime
+import os
 
 import frappe
-from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
 from erpnext.setup.utils import enable_all_roles_and_domains, set_defaults_for_tests
-from erpnext.accounts.doctype.account.account import update_account_number
+from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
+from frappe.installer import update_site_config
 
-from approvals.tests.fixtures import (
-	suppliers,
-	tax_authority,
-	pi_dars,
-	users,
-	script_text,
-)
+from approvals.tests.fixtures import pi_dars, script_text, suppliers, tax_authority, users
 
 
 def before_test():
@@ -190,6 +185,10 @@ def create_client_script():
 
 
 def create_server_script(script_text):
+	sites_path = os.getcwd()
+	common_site_config_path = os.path.join(sites_path, "common_site_config.json")
+	update_site_config("server_script_enabled", True, site_config_path=common_site_config_path)
+
 	da = frappe.new_doc("Server Script")
 	da.name = "Assign Approvers - Purchase Invoice"
 	# da.group = 'on_update'  # no `group` field in DocType


### PR DESCRIPTION
```python
Updating Dashboard for frappe
Updating Dashboard for erpnext
Updating Dashboard for hrms
Updating Dashboard for approvals
Traceback (most recent call last):
  File "/home/rohan/erpn15/apps/frappe/frappe/commands/utils.py", line 269, in execute
    ret = frappe.get_attr(method)(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/apps/approvals/approvals/tests/setup.py", line 42, in before_test
    create_test_data()
  File "/home/rohan/erpn15/apps/approvals/approvals/tests/setup.py", line 70, in create_test_data
    create_invoices(settings)
  File "/home/rohan/erpn15/apps/approvals/approvals/tests/setup.py", line 119, in create_invoices
    pi.save()
  File "/home/rohan/erpn15/apps/frappe/frappe/model/document.py", line 337, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/apps/frappe/frappe/model/document.py", line 359, in _save
    return self.insert()
           ^^^^^^^^^^^^^
  File "/home/rohan/erpn15/apps/frappe/frappe/model/document.py", line 315, in insert
    self.run_post_save_methods()
  File "/home/rohan/erpn15/apps/frappe/frappe/model/document.py", line 1128, in run_post_save_methods
    self.run_method("on_update")
  File "/home/rohan/erpn15/apps/frappe/frappe/model/document.py", line 966, in run_method
    run_server_script_for_doc_event(self, method)
  File "/home/rohan/erpn15/apps/frappe/frappe/core/doctype/server_script/server_script_utils.py", line 42, in run_server_script_for_doc_event
    frappe.get_doc("Server Script", script_name).execute_doc(doc)
  File "/home/rohan/erpn15/apps/frappe/frappe/core/doctype/server_script/server_script.py", line 169, in execute_doc
    safe_exec(
  File "/home/rohan/erpn15/apps/frappe/frappe/utils/safe_exec.py", line 92, in safe_exec
    frappe.throw(msg, ServerScriptNotEnabled, title="Server Scripts Disabled")
  File "/home/rohan/erpn15/apps/frappe/frappe/__init__.py", line 645, in throw
    msgprint(
  File "/home/rohan/erpn15/apps/frappe/frappe/__init__.py", line 610, in msgprint
    _raise_exception()
  File "/home/rohan/erpn15/apps/frappe/frappe/__init__.py", line 561, in _raise_exception
    raise exc
frappe.utils.safe_exec.ServerScriptNotEnabled: Server Scripts are disabled. Please enable server scripts from bench configuration.Read the documentation to know more

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/rohan/erpn15/apps/frappe/frappe/utils/bench_helper.py", line 114, in <module>
    main()
  File "/home/rohan/erpn15/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/rohan/erpn15/env/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/env/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/env/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/env/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/env/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/env/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/env/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/rohan/erpn15/apps/frappe/frappe/commands/utils.py", line 272, in execute
    ret = eval(method + "(*args, **kwargs)", globals(), locals())  # nosemgrep
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
NameError: name 'approvals' is not defined
```