### PR TITLE
fix: enable server script before creating invoices

### DIFF
--- a/approvals/approvals/doctype/user_document_approval/user_document_approval.py
+++ b/approvals/approvals/doctype/user_document_approval/user_document_approval.py
@@ -35,4 +35,4 @@ class UserDocumentApproval(Document):
 			"ToDo", {"reference_name": self.reference_name, "owner": self.approver}, "name"
 		)
 		if todo:
-			frappe.delete_doc('ToDo', todo, force=True)
+			frappe.delete_doc("ToDo", todo, force=True)

--- a/approvals/tests/setup.py
+++ b/approvals/tests/setup.py
@@ -1,9 +1,10 @@
 import datetime
+import os
 
 import frappe
-from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
 from erpnext.setup.utils import enable_all_roles_and_domains, set_defaults_for_tests
-from erpnext.accounts.doctype.account.account import update_account_number
+from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
+from frappe.installer import update_site_config
 
 from approvals.tests.fixtures import (
 	suppliers,
@@ -191,6 +192,10 @@ def create_client_script(settings):
 
 
 def create_server_script(settings):
+	sites_path = os.getcwd()
+	common_site_config_path = os.path.join(sites_path, "common_site_config.json")
+	update_site_config("server_script_enabled", True, site_config_path=common_site_config_path)
+
 	da = frappe.new_doc("Server Script")
 	da.name = "Assign Approvers - Purchase Invoice"
 	# da.group = 'on_update'  # no `group` field in DocType


### PR DESCRIPTION
Backporting #19

---

Server scripts are enabled by default in v14, but backporting to v14 anyway